### PR TITLE
Rearranging nav link spacing when in 320px

### DIFF
--- a/style.css
+++ b/style.css
@@ -769,10 +769,10 @@ li.menu-item-w3 {
 		float: left;
 		width: 45%;
 	}
-	.header .nav li:nth-child(even) {
+	.header .nav li:nth-last-child(even) {
 		margin-right: 5%;
 	}
-	.header .nav li:nth-child(odd) {
+	.header .nav li:nth-last-child(odd) {
 		margin-left: 5%;
 	}
 	.nav .menu-item-home {


### PR DESCRIPTION
The main nav links were meant to be evenly spaced, but my code expected a home link to increment the index by one. This rids us of this prerequisite.
